### PR TITLE
ensure basic.t always runs under CI environment

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -1,5 +1,11 @@
 use strict;
-use Acme::Test::VW;
+
+BEGIN {
+    local $ENV{'CI'} = 1;
+    require Acme::Test::VW;
+    Acme::Test::VW->import();
+}
+
 use Test::More;
 
 is 1, 2;


### PR DESCRIPTION
I wasn't a fan of how the tests pass if you run them "normally" with
prove or ./Build test.
